### PR TITLE
adding .src to hash.get results

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,9 +105,8 @@ function set(pathname, handler) {
         }
     }
 
-    hash.src = pathname;
-
     if (!hash.handler) {
+        hash.src = pathname;
         hash.handler = handler;
     } else {
         throw RouteConflictError(pathname, hash);

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ function HttpHash() {
         return new HttpHash();
     }
 
-    this._hash = new RouteNode(null, null, false, "/");
+    this._hash = new RouteNode(null, null, false, '/');
 }
 
 HttpHash.prototype.get = get;

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ function HttpHash() {
         return new HttpHash();
     }
 
-    this._hash = new RouteNode();
+    this._hash = new RouteNode(null, null, false, "/");
 }
 
 HttpHash.prototype.get = get;
@@ -63,6 +63,8 @@ function set(pathname, handler) {
     for (var i = 0; i < pathSegments.length; i++) {
         var segment = pathSegments[i];
 
+        var srcThusFar = pathSegments.slice(0, i + 1).join('/');
+
         if (!segment) {
             continue;
         }
@@ -70,7 +72,7 @@ function set(pathname, handler) {
         if (hasSplat && i === lastIndex) {
             hash = (
                 hash.variablePaths ||
-                (hash.variablePaths = new RouteNode(hash, segment, true))
+                (hash.variablePaths = new RouteNode(hash, segment, true, srcThusFar))
             );
 
             if (!hash.isSplat) {
@@ -80,7 +82,7 @@ function set(pathname, handler) {
             segment = segment.slice(1);
             hash = (
                 hash.variablePaths ||
-                (hash.variablePaths = new RouteNode(hash, segment))
+                (hash.variablePaths = new RouteNode(hash, segment, false, srcThusFar))
             );
 
             if (hash.segment !== segment || hash.isSplat) {
@@ -92,7 +94,7 @@ function set(pathname, handler) {
                     hash.hasOwnProperty('proto') &&
                     hash.proto
                 ) ||
-                (hash.proto = new RouteNode(hash, segment))
+                (hash.proto = new RouteNode(hash, segment, false, srcThusFar))
             );
         } else {
             hash = (
@@ -100,7 +102,7 @@ function set(pathname, handler) {
                     hash.staticPaths.hasOwnProperty(segment) &&
                     hash.staticPaths[segment]
                 ) ||
-                (hash.staticPaths[segment] = new RouteNode(hash, segment))
+                (hash.staticPaths[segment] = new RouteNode(hash, segment, false, srcThusFar))
             );
         }
     }
@@ -112,19 +114,21 @@ function set(pathname, handler) {
     }
 }
 
-function RouteNode(parent, segment, isSplat) {
+function RouteNode(parent, segment, isSplat, src) {
     this.parent = parent || null;
     this.segment = segment || null;
     this.handler = null;
     this.staticPaths = {};
     this.variablePaths = null;
     this.isSplat = !!isSplat;
+    this.src = src || null;
 }
 
 function RouteResult(node, params, splat) {
     this.handler = node && node.handler || null;
     this.splat = splat;
     this.params = params;
+    this.src = node && node.src;
 }
 
 function SplatError(pathname) {

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ function HttpHash() {
         return new HttpHash();
     }
 
-    this._hash = new RouteNode(null, null, false, '/');
+    this._hash = new RouteNode();
 }
 
 HttpHash.prototype.get = get;
@@ -63,8 +63,6 @@ function set(pathname, handler) {
     for (var i = 0; i < pathSegments.length; i++) {
         var segment = pathSegments[i];
 
-        var srcThusFar = pathSegments.slice(0, i + 1).join('/');
-
         if (!segment) {
             continue;
         }
@@ -72,7 +70,7 @@ function set(pathname, handler) {
         if (hasSplat && i === lastIndex) {
             hash = (
                 hash.variablePaths ||
-                (hash.variablePaths = new RouteNode(hash, segment, true, srcThusFar))
+                (hash.variablePaths = new RouteNode(hash, segment, true))
             );
 
             if (!hash.isSplat) {
@@ -82,7 +80,7 @@ function set(pathname, handler) {
             segment = segment.slice(1);
             hash = (
                 hash.variablePaths ||
-                (hash.variablePaths = new RouteNode(hash, segment, false, srcThusFar))
+                (hash.variablePaths = new RouteNode(hash, segment))
             );
 
             if (hash.segment !== segment || hash.isSplat) {
@@ -94,7 +92,7 @@ function set(pathname, handler) {
                     hash.hasOwnProperty('proto') &&
                     hash.proto
                 ) ||
-                (hash.proto = new RouteNode(hash, segment, false, srcThusFar))
+                (hash.proto = new RouteNode(hash, segment))
             );
         } else {
             hash = (
@@ -102,10 +100,12 @@ function set(pathname, handler) {
                     hash.staticPaths.hasOwnProperty(segment) &&
                     hash.staticPaths[segment]
                 ) ||
-                (hash.staticPaths[segment] = new RouteNode(hash, segment, false, srcThusFar))
+                (hash.staticPaths[segment] = new RouteNode(hash, segment))
             );
         }
     }
+
+    hash.src = pathname;
 
     if (!hash.handler) {
         hash.handler = handler;
@@ -114,21 +114,21 @@ function set(pathname, handler) {
     }
 }
 
-function RouteNode(parent, segment, isSplat, src) {
+function RouteNode(parent, segment, isSplat) {
     this.parent = parent || null;
     this.segment = segment || null;
     this.handler = null;
     this.staticPaths = {};
     this.variablePaths = null;
     this.isSplat = !!isSplat;
-    this.src = src || null;
+    this.src = null;
 }
 
 function RouteResult(node, params, splat) {
     this.handler = node && node.handler || null;
     this.splat = splat;
     this.params = params;
-    this.src = node && node.src;
+    this.src = node && node.src || null;
 }
 
 function SplatError(pathname) {

--- a/test/index.js
+++ b/test/index.js
@@ -69,6 +69,7 @@ test('http hash retrieves root', function (assert) {
 
     // Assert
     assert.strictEqual(result.handler, routeHandler);
+    assert.strictEqual(result.src, '/');
     assert.strictEqual(result.splat, null);
     assert.deepEqual(result.params, expectedParams);
     assert.end();
@@ -88,6 +89,7 @@ test('http hash retrieves fixed route', function (assert) {
 
     // Assert
     assert.strictEqual(result.handler, routeHandler);
+    assert.strictEqual(result.src, '/test');
     assert.strictEqual(result.splat, null);
     assert.deepEqual(result.params, expectedParams);
     assert.end();
@@ -108,6 +110,7 @@ test('http hash retrieves variable route', function (assert) {
 
     // Assert
     assert.strictEqual(result.handler, routeHandler);
+    assert.strictEqual(result.src, '/:test');
     assert.strictEqual(result.splat, null);
     assert.deepEqual(result.params, expectedParams);
     assert.end();
@@ -289,7 +292,6 @@ test('nesting routes', function (assert) {
     // there should be 3 conflicts violation of variable name
     assert.strictEqual(conflicts.length, 3);
 
-    console.log(conflicts);
     assert.strictEqual(conflicts[0], '2,0');
     assert.strictEqual(conflicts[1], '2,1');
     assert.strictEqual(conflicts[2], '2,2');
@@ -315,6 +317,7 @@ test('deep route with splat test', function (assert) {
     var result = hash.get('/a/123456///b///testing/c/kersplat');
 
     // Assert
+    assert.strictEqual(result.src, "/a/:varA/b/:varB/c/*");
     assert.strictEqual(result.handler, routeHandler);
     assert.strictEqual(result.splat, expectedSplat);
     assert.deepEqual(result.params, expectedParams);
@@ -358,10 +361,12 @@ test('static routes work on splat nodes', function (assert) {
     var staticResult = hash.get('/static');
 
     // Assert
+    assert.strictEqual(splatResult.src, "*");
     assert.strictEqual(splatResult.handler, splatHandler);
     assert.strictEqual(splatResult.splat, 'testing');
     assert.deepEqual(splatResult.params, {});
 
+    assert.strictEqual(staticResult.src, "/static");
     assert.strictEqual(staticResult.handler, staticHandler);
     assert.strictEqual(staticResult.splat, null);
     assert.deepEqual(staticResult.params, {});
@@ -438,6 +443,7 @@ test('does not conflict with prototype', function (assert) {
     assert.strictEqual(toStringResult.handler, null);
     assert.strictEqual(valueOfResult.handler, null);
     assert.strictEqual(pathResult.handler, validHandler);
+    assert.strictEqual(pathResult.src, '/toString/valueOf');
     assert.end();
 });
 
@@ -458,7 +464,9 @@ test('does not conflict with __proto__', function (assert) {
 
     // Assert
     assert.strictEqual(validResult.handler, validHandler);
+    assert.strictEqual(validResult.src, '/__proto__');
     assert.strictEqual(validSubResult.handler, validSubHandler);
+    assert.strictEqual(validSubResult.src, '/__proto__/sub');
     assert.strictEqual(invalidResult.handler, null);
     assert.end();
 });


### PR DESCRIPTION
Adds `.src` on `RouteResult`s for easier instrumenting

cc @Raynos @sh1mmer
