### PR TITLE
Use npm-standard license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,7 @@
     "tap-spec": "^0.1.8",
     "tape": "^2.12.3"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/Matt-Esch/http-hash/raw/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "scripts": {
     "test": "npm run jshint -s && NODE_ENV=test node test/index.js | tap-spec",
     "unit-test": "NODE_ENV=test node test/index.js | tap-spec",


### PR DESCRIPTION
Matt,

Many thanks for this package!  I've used it in all kinds of projects.  I really, really like the approach.

This tiny PR fixes the license metadata in `package.json` to conform to [npm's guidelines](https://docs.npmjs.com/files/package.json#license). Fair is fair: I was involved in writing those guidelines.  The idea is to make it easy to automate license checks even for really deep `node_modules` directories.  Running an automatic tool is exactly what tipped me off about `http-hash`.

The old `licenses` Array was definitely a thing in the early days of node, which took a lot from RubyGems.  I believe the original CommonJS spec actually mentioned it.  For various reasons, it's turned out to be noisier and less expressive than proper SPDX (license metadata standard) expressions.

I can't answer legal questions, but if you have any questions about metadata or the npm guidelines, feel free to hit me up.

Again, thanks very much for the package!

Best,

K
